### PR TITLE
minor code style improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,8 @@ new backups, and to read archived data.
 If you'd like to contribute to Kaya, feel free to open an issue or pull
 request, or email me with a link to your branch.
 
+Kaya's bash files use emacs standard indentation. To indent FILE, run
+
+```
+emacs FILE --batch --eval '(progn (indent-region (point-min) (point-max)) (save-buffer))'
+```

--- a/kaya
+++ b/kaya
@@ -89,6 +89,7 @@ get-params() {
     case $action in
         backup)
             # currently the only option is to backup
+            true
             ;;
         *)
             echo "kaya: error: invalid action argument: $action" >&2
@@ -138,8 +139,8 @@ start-backup() {
 
     # make the backup over a forwarded port
     cat << EOF | ssh -o PasswordAuthentication=no -R "${remote_port}:localhost:${local_port}" \
-        "${remote_user}@${hostname}" kaya-client \
-        "${remote_port@Q}" "${hostname@Q}" "${backup_options[@]@Q}" \
+                     "${remote_user}@${hostname}" kaya-client \
+                     "${remote_port@Q}" "${hostname@Q}" "${backup_options[@]@Q}" \
         | tee "${log_dump}" | { grep -v "KAYA_SUCCESSFUL_BACKUP_MESSAGE" ||:; }
 ${kaya_protocol_version}
 ${password}
@@ -215,3 +216,6 @@ main() {
 
 main "$@"
 
+# Local Variables:
+# sh-basic-offset: 4
+# End:

--- a/kaya-client
+++ b/kaya-client
@@ -30,6 +30,7 @@ read -r kaya_protocol_version
 
 case $kaya_protocol_version in
     1|2)
+        true
         ;;
     *)
         echo "kaya-client: error: mismatched protocol version with kaya" >&2
@@ -57,15 +58,22 @@ ret=0
 case $ret in
     0)
         # success
+        true
         ;;
     3)
         # restic warning, such as file randomly disappearing during backup
         # consider it success
+        true
         ;;
     *)
-    echo "kaya-client: command exit code $ret: ${cmd[*]}" >&2
-    exit $ret
+	echo "kaya-client: command exit code $ret: ${cmd[*]}" >&2
+	exit $ret
+        ;;
 esac
 
 # needed in case ssh dies on the backup server, and exits with 0 (patched in OpenSSH version 8.8)
 if [[ $kaya_protocol_version -ge 2 ]] ; then echo "KAYA_SUCCESSFUL_BACKUP_MESSAGE" ; fi
+
+# Local Variables:
+# sh-basic-offset: 4
+# End:


### PR DESCRIPTION
* Use emacs auto-indentation & document cli command to auto-indent for
  non-emacs users. Automatic indent allows for easier and consistent
  contribution.

* Add explicit true for empty case conditions. This makes it clear it
  wasn't mistakenly empty and emacs indents it more consistently.

* Set emacs config for indent level to help emacs users.